### PR TITLE
Updates for 0.4.1.

### DIFF
--- a/examples/create-command-namespaced.js
+++ b/examples/create-command-namespaced.js
@@ -63,6 +63,7 @@ const multiplyCommand = createCommand({
 const mathCommand = createCommand({
   isParent: true,
   name: 'math',
+  alias: 'math:',
   description: 'Math-related commands.',
 }, [
   addCommand,
@@ -91,13 +92,13 @@ function simulate(messageHandler, message) {
 Promise.mapSeries([
   () => simulate(mathCommand, 'hello'),
   () => simulate(mathCommand, 'help'),
-  () => simulate(mathCommand, 'math hello'),
-  () => simulate(mathCommand, 'math help'),
+  () => simulate(mathCommand, 'math: hello'),
+  () => simulate(mathCommand, 'math: help'),
   () => simulate(mathCommand, 'math help add'),
-  () => simulate(mathCommand, 'math help add 3 4 5'),
-  () => simulate(mathCommand, 'math add 3 4 5'),
+  () => simulate(mathCommand, 'math: help add 3 4 5'),
+  () => simulate(mathCommand, 'math: add 3 4 5'),
   () => simulate(mathCommand, 'math multiply'),
   () => simulate(mathCommand, 'math multiply three four five'),
-  () => simulate(mathCommand, 'math help multiply'),
+  () => simulate(mathCommand, 'math: help multiply'),
   () => simulate(mathCommand, 'math multiply 3 4 5'),
 ], f => f());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A collection of useful primitives for creating interactive chat bots.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/message-handler/command.js
+++ b/src/message-handler/command.js
@@ -11,7 +11,7 @@ export class CommandMessageHandler extends DelegatingMessageHandler {
 
   constructor(options = {}, children) {
     super(options, children);
-    const {name, usage, description, details, isParent} = options;
+    const {name, aliases, usage, description, details, isParent} = options;
     this.isCommand = true;
     this.name = name;
     this.usage = usage;
@@ -33,10 +33,18 @@ export class CommandMessageHandler extends DelegatingMessageHandler {
     }
     // Keep track of this command's sub-commands for later use.
     this.subCommands = this.children.filter(c => c.isCommand);
-    // If this command has a name, create a matching wrapper around children
-    // that responds only to this command's name.
-    if (name) {
-      this.children = createMatcher({match: name}, this.children);
+    // If this command has a name or aliases, create a matching wrapper around
+    // children that responds only to that name or an alias.
+    if (name || aliases) {
+      const items = !aliases ? [] : Array.isArray(aliases) ? aliases : [aliases];
+      if (name) {
+        items.unshift(name);
+      }
+      const origChildren = this.children;
+      this.children = items.map(item => createMatcher({match: item}, origChildren));
+      if (!name) {
+        this.children.push(origChildren);
+      }
     }
   }
 

--- a/src/message-handler/command.test.js
+++ b/src/message-handler/command.test.js
@@ -1,0 +1,115 @@
+import Promise from 'bluebird';
+import createCommand, {CommandMessageHandler} from './command';
+
+const nop = () => {};
+
+describe('message-handler/command', function() {
+
+  it('should export the proper API', function() {
+    expect(createCommand).to.be.a('function');
+    expect(CommandMessageHandler).to.be.a('function');
+  });
+
+  describe('createCommand', function() {
+
+    it('should return an instance of CommandMessageHandler', function() {
+      const command = createCommand({name: 'foo', handleMessage: []});
+      expect(command).to.be.an.instanceof(CommandMessageHandler);
+    });
+
+  });
+
+  describe('CommandMessageHandler', function() {
+
+    describe('constructor', function() {
+
+      it('should behave like DelegatingMessageHandler', function() {
+        expect(() => createCommand({name: 'foo'}, nop)).to.not.throw();
+        expect(() => createCommand({name: 'foo'})).to.throw(/missing.*message.*handler/i);
+      });
+
+    });
+
+    describe('handleMessage', function() {
+
+      it('should return a promise that gets fulfilled', function() {
+        const command = createCommand({name: 'foo'}, nop);
+        return expect(command.handleMessage()).to.be.fulfilled();
+      });
+
+      it('should match messages starting with the command name', function() {
+        const command = createCommand({name: 'foo'}, [
+          message => message === 'xyz' && 'xyz-match',
+          message => message,
+        ]);
+        return Promise.all([
+          expect(command.handleMessage('foo')).to.become(''),
+          expect(command.handleMessage('foo ')).to.become(''),
+          expect(command.handleMessage('foo bar')).to.become('bar'),
+          expect(command.handleMessage('foo    bar')).to.become('bar'),
+          expect(command.handleMessage('foo xyz')).to.become('xyz-match'),
+          expect(command.handleMessage('foo-bar')).to.become(false),
+        ]);
+      });
+
+      it('should match messages starting with the command name or an alias', function() {
+        const command = createCommand({name: 'foo', aliases: ['aaa', 'aaa:']}, [
+          message => message === 'xyz' && 'xyz-match',
+          message => message,
+        ]);
+        return Promise.all([
+          // name
+          expect(command.handleMessage('foo')).to.become(''),
+          expect(command.handleMessage('foo ')).to.become(''),
+          expect(command.handleMessage('foo bar')).to.become('bar'),
+          expect(command.handleMessage('foo    bar')).to.become('bar'),
+          expect(command.handleMessage('foo xyz')).to.become('xyz-match'),
+          // alias 1
+          expect(command.handleMessage('aaa')).to.become(''),
+          expect(command.handleMessage('aaa ')).to.become(''),
+          expect(command.handleMessage('aaa bar')).to.become('bar'),
+          expect(command.handleMessage('aaa    bar')).to.become('bar'),
+          expect(command.handleMessage('aaa xyz')).to.become('xyz-match'),
+          // alias 2
+          expect(command.handleMessage('aaa:')).to.become(''),
+          expect(command.handleMessage('aaa: ')).to.become(''),
+          expect(command.handleMessage('aaa: bar')).to.become('bar'),
+          expect(command.handleMessage('aaa:    bar')).to.become('bar'),
+          expect(command.handleMessage('aaa: xyz')).to.become('xyz-match'),
+          // messages that don't match the name or an alias just fail
+          expect(command.handleMessage('aaa-bar')).to.become(false),
+          expect(command.handleMessage('aaa:bar')).to.become(false),
+          expect(command.handleMessage('xyz')).to.become(false),
+        ]);
+      });
+
+      it('should match messages starting with no name but with an alias', function() {
+        const command = createCommand({aliases: ['aaa', 'aaa:']}, [
+          message => message === 'xyz' && 'xyz-match',
+          message => message,
+        ]);
+        return Promise.all([
+          // alias 1
+          expect(command.handleMessage('aaa')).to.become(''),
+          expect(command.handleMessage('aaa ')).to.become(''),
+          expect(command.handleMessage('aaa bar')).to.become('bar'),
+          expect(command.handleMessage('aaa    bar')).to.become('bar'),
+          expect(command.handleMessage('aaa xyz')).to.become('xyz-match'),
+          // alias 2
+          expect(command.handleMessage('aaa:')).to.become(''),
+          expect(command.handleMessage('aaa: ')).to.become(''),
+          expect(command.handleMessage('aaa: bar')).to.become('bar'),
+          expect(command.handleMessage('aaa:    bar')).to.become('bar'),
+          expect(command.handleMessage('aaa: xyz')).to.become('xyz-match'),
+          // not matched
+          expect(command.handleMessage('aaa-bar')).to.become('aaa-bar'),
+          expect(command.handleMessage('aaa:bar')).to.become('aaa:bar'),
+          expect(command.handleMessage('xyz')).to.become('xyz-match'),
+        ]);
+      });
+
+    });
+
+  });
+
+});

--- a/src/message-handler/matcher.js
+++ b/src/message-handler/matcher.js
@@ -45,7 +45,7 @@ export class MatchingMessageHandler extends DelegatingMessageHandler {
     if (typeof match === 'function') {
       return match(message, ...args);
     }
-    else if (typeof match === 'string') {
+    else if (typeof match === 'string' || match instanceof RegExp) {
       return matchStringOrRegex(match, message);
     }
     throw new TypeError('Invalid "match" option format.');

--- a/src/slack/slack-bot.js
+++ b/src/slack/slack-bot.js
@@ -206,6 +206,21 @@ export class SlackBot extends Bot {
       .then(() => Promise.delay(this.postMessageDelay));
   }
 
+  // Get the bot's name and a list of aliases suitable for use in a top-level
+  // command message handler.
+  getBotNameAndAliases() {
+    const {activeUserId, dataStore} = this.slack.rtmClient;
+    // Bot name.
+    const botName = dataStore.getUserById(activeUserId).name;
+    // Aliases for a top-level bot command.
+    const aliases = [
+      `${botName}:`,
+      `<@${activeUserId}>`,
+      `<@${activeUserId}>:`,
+    ];
+    return {botName, aliases};
+  }
+
 }
 
 export default function createSlackBot(options) {


### PR DESCRIPTION
* Ensure matching message handler works with a regex matcher.
* Allow commands to have aliases. Closes #32.
* Add SlackBot convenience method for getting bot name and aliases.