### PR TITLE
Make SlackBot "getBotNameAndAliases" method smarter.

### DIFF
--- a/examples/slack-bot.js
+++ b/examples/slack-bot.js
@@ -158,39 +158,35 @@ const bot = createSlackBot({
   // to handle each message.
   createMessageHandler(id, meta) {
     const channel = meta.channel;
+    // Get actual bot name and aliases for the bot. If the bot's actual name in
+    // Slack was "test", the aliases would be "test:" "@test" "@test:", allowing
+    // the bot to respond to commands prefixed with any of them. If the channel
+    // is a DM, the bot name will be null, and the actual name will be added to
+    // the aliases list, so the bot can respond to both prefixed and non-
+    // prefixed messages. Alternately, specify your own bot name and aliases!
+    const nameObj = this.getBotNameAndAliases(channel.is_im);
+    console.log(nameObj);
+    // Create the top-level command.
+    const rootCommand = createCommand({
+      isParent: true,
+      name: nameObj.name,
+      aliases: nameObj.aliases,
+      description: `Hi, I'm the test bot!`,
+    }, [
+      delayCommand,
+      echoCommand,
+      mathCommand,
+    ]);
     // Direct message.
     if (channel.is_im) {
-      // In direct messages, top-level commands don't need a name, because all
-      // messages come from the one user in the DM. You can use a name if you
-      // want, though!
-      return createCommand({
-        isParent: true,
-        description: `Hi, I'm the test bot!`,
-      }, [
-        delayCommand,
-        echoCommand,
-        mathCommand,
-      ]);
+      return rootCommand;
     }
     // Public channel message.
     return [
-      // In public channels, top-level commands should have a name, so that
-      // the command's fallback message handler doesn't trigger for every
-      // single non-command message. Practically, this just means you have to
-      // prefix all commands with the name, like "bot echo hello". You can omit
-      // the name if you really want, though!
-      createCommand({
-        name: 'bot',
-        isParent: true,
-        description: `Hi, I'm the test bot!`,
-      }, [
-        delayCommand,
-        echoCommand,
-        mathCommand,
-      ]),
+      rootCommand,
       // You can certainly combine commands and other message handlers, as long
       // as the command has a name. (If the command didn't have a name, it would
-      // handle all messages, and the following would never run).
+      // handle all messages, and message handlers after it would never run).
       helloHandler,
       lolHandler,
     ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatter",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A collection of useful primitives for creating interactive chat bots.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/slack/slack-bot.js
+++ b/src/slack/slack-bot.js
@@ -207,18 +207,24 @@ export class SlackBot extends Bot {
   }
 
   // Get the bot's name and a list of aliases suitable for use in a top-level
-  // command message handler.
-  getBotNameAndAliases() {
+  // command message handler. If "isIm" is true, set "name" to null and add
+  // the bot name to the list of aliases, so the bot will both respond to the
+  // name (or any other aliases) but also to un-prefixed messages.
+  getBotNameAndAliases(isIm = false) {
     const {activeUserId, dataStore} = this.slack.rtmClient;
     // Bot name.
-    const botName = dataStore.getUserById(activeUserId).name;
+    let name = dataStore.getUserById(activeUserId).name;
     // Aliases for a top-level bot command.
     const aliases = [
-      `${botName}:`,
+      `${name}:`,
       `<@${activeUserId}>`,
       `<@${activeUserId}>:`,
     ];
-    return {botName, aliases};
+    if (isIm) {
+      aliases.unshift(name);
+      name = null;
+    }
+    return {name, aliases};
   }
 
 }


### PR DESCRIPTION
There's a current issue in how we're using `getBotNameAndAliases`, which would result in having to update the current user-land code (using `chatter@0.4.1`):

```js
createMessageHandler(id, {channel}) {
  const {botName, aliases} = this.getBotNameAndAliases();
  const name = channel.is_im ? null : botName;
  return createCommand({
    isParent: true,
    name,
    aliases,
    description: 'Yay!',
  }, [
    subCommand,
  ]);
}
```

To the fairly convoluted:

```js
createMessageHandler(id, {channel}) {
  const {botName, aliases: aliasList} = this.getBotNameAndAliases();
  const name = channel.is_im ? null : botName;
  const aliases = channel.is_im ? aliasList.concat(name) : aliasList;
  return createCommand({
    isParent: true,
    name,
    aliases,
    description: 'Yay!',
  }, [
    subCommand,
  ]);
}
```

Instead, by updating `getBotNameAndAliases` to accept a boolean `isIm` argument, user-land code can be greatly simplified, for what has become the most common use-case:

```js
createMessageHandler(id, {channel}) {
  const {name, aliases} = this.getBotNameAndAliases(channel.is_im);
  return createCommand({
    isParent: true,
    name,
    aliases,
    description: 'Yay!',
  }, [
    subCommand,
  ]);
}
```