### PR TITLE
Escape special regex characters in matchStringOrRegex()

### DIFF
--- a/src/message-handler/matcher.js
+++ b/src/message-handler/matcher.js
@@ -1,6 +1,12 @@
 import Promise from 'bluebird';
 import {DelegatingMessageHandler} from './delegate';
 
+// Escape special characters that would cause errors if we interpolate them
+// into a regex.
+function regexEscape(expr) {
+  return expr.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 // If "match" is a String and matches the entire message or matches a space-
 // delimited word at the beginning of the message, success. If any text
 // remains after the match, return it (with leading spaces stripped) as the
@@ -9,7 +15,7 @@ import {DelegatingMessageHandler} from './delegate';
 // If match is a RegExp and matches the message, return the value of the
 // first non-undefined (ie. captured) capture group.
 export function matchStringOrRegex(match, message = '') {
-  const re = typeof match === 'string' ? new RegExp(`^${match}(?:$|\\s+(.*))`, 'i') : match;
+  const re = typeof match === 'string' ? new RegExp(`^${regexEscape(match)}(?:$|\\s+(.*))`, 'i') : match;
   const [fullMatch, ...captures] = message.match(re) || [];
   if (typeof fullMatch !== 'string') {
     return false;

--- a/src/message-handler/matcher.test.js
+++ b/src/message-handler/matcher.test.js
@@ -70,8 +70,10 @@ describe('message-handler/matcher', function() {
     });
 
     it('should escape regex special characters', function() {
-      expect(matchStringOrRegex('+', '')).to.equal(false);
+      expect(matchStringOrRegex('+[]/-^$*.?()\\|', '')).to.equal(false);
+      expect(matchStringOrRegex('\\w+', 'foo')).to.equal(false);
       expect(matchStringOrRegex('+', '+')).to.equal('');
+      expect(matchStringOrRegex('\\w+', '\\w+')).to.equal('');
     });
 
   });

--- a/src/message-handler/matcher.test.js
+++ b/src/message-handler/matcher.test.js
@@ -69,6 +69,11 @@ describe('message-handler/matcher', function() {
       expect(matchStringOrRegex(re, 'foo')).to.equal('');
     });
 
+    it('should escape regex special characters', function() {
+      expect(matchStringOrRegex('+', '')).to.equal(false);
+      expect(matchStringOrRegex('+', '+')).to.equal('');
+    });
+
   });
 
   describe('createMatcher', function() {


### PR DESCRIPTION
Not sure if this repo is still being maintained, but I hit a nasty bug that took a bit of doing to track down. `matchStringOrRegex` happily interpolates any string value directly into a RegExp constructor, which means if it's passed any special characters it'll probably build a regular expression that throws or does something you don't want.

For example, I had a command aliased to '+', which meant `matchStringOrRegex` was throwing something like `SyntaxError: Invalid regular expression: /^+(?:$|\s+(.*))/: Nothing to repeat` (see what happened there?)

This PR wraps the value being interpolated into the regex with a function that escapes special characters. It's grabbed from the `RegExp.escape` proposal [here](https://github.com/benjamingr/RegExp.escape) for simplicity, though if you really wanted to pull in a new dependency [this](https://github.com/sindresorhus/escape-string-regexp) also exists.
